### PR TITLE
Use uv for Python dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,15 @@ RUN npm run build
 FROM python:3.11-slim AS backend-builder
 WORKDIR /app
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN curl -Ls https://astral.sh/uv/install.sh | sh && \
+    uv pip install --no-cache-dir -r requirements.txt
 
 # Stage 3: Final Image
 FROM python:3.11-slim
 WORKDIR /app
+
+# Install uv for package management
+RUN curl -Ls https://astral.sh/uv/install.sh | sh
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/README.es.md
+++ b/README.es.md
@@ -168,8 +168,11 @@ cd tavily-company-research
 python -m venv .venv
 source .venv/bin/activate
 
-# Instalar dependencias de Python
-pip install -r requirements.txt
+# Instalar el gestor de paquetes uv
+curl -Ls https://astral.sh/uv/install.sh | bash
+
+# Instalar dependencias de Python con uv
+uv pip install -r requirements.txt
 ```
 
 3. Instalar dependencias de frontend:
@@ -260,7 +263,7 @@ npm run dev
    **Opción 2: FastAPI con Uvicorn**
    ```bash
    # Instalar uvicorn si aún no está instalado
-   pip install uvicorn
+   uv pip install uvicorn
 
    # Ejecutar la aplicación FastAPI con recarga automática
    uvicorn application:app --reload --port 8000
@@ -286,7 +289,7 @@ La aplicación puede desplegarse en varias plataformas en la nube. Aquí hay alg
 
 1. Instalar el EB CLI:
    ```bash
-   pip install awsebcli
+   uv pip install awsebcli
    ```
 
 2. Inicializar la aplicación EB:

--- a/README.fr.md
+++ b/README.fr.md
@@ -169,8 +169,11 @@ cd tavily-company-research
 python -m venv .venv
 source .venv/bin/activate
 
-# Installez les dépendances Python
-pip install -r requirements.txt
+# Installez le gestionnaire de paquets uv
+curl -Ls https://astral.sh/uv/install.sh | bash
+
+# Installez les dépendances Python avec uv
+uv pip install -r requirements.txt
 ```
 
 3. Installez les dépendances frontend :
@@ -261,7 +264,7 @@ npm run dev
    **Option 2 : FastAPI avec Uvicorn**
    ```bash
    # Installez uvicorn si ce n'est pas déjà fait
-   pip install uvicorn
+   uv pip install uvicorn
 
    # Exécutez l'application FastAPI avec rechargement à chaud
    uvicorn application:app --reload --port 8000
@@ -287,7 +290,7 @@ L'application peut être déployée sur diverses plateformes cloud. Voici quelqu
 
 1. Installez l'EB CLI :
    ```bash
-   pip install awsebcli
+   uv pip install awsebcli
    ```
 
 2. Initialisez l'application EB :

--- a/README.md
+++ b/README.md
@@ -169,8 +169,11 @@ cd tavily-company-research
 python -m venv .venv
 source .venv/bin/activate
 
-# Install Python dependencies
-pip install -r requirements.txt
+# Install uv (package manager)
+curl -Ls https://astral.sh/uv/install.sh | bash
+
+# Install Python dependencies using uv
+uv pip install -r requirements.txt
 ```
 
 3. Install frontend dependencies:
@@ -261,7 +264,7 @@ npm run dev
    **Option 2: FastAPI with Uvicorn**
    ```bash
    # Install uvicorn if not already installed
-   pip install uvicorn
+   uv pip install uvicorn
 
    # Run the FastAPI application with hot reload
    uvicorn application:app --reload --port 8000
@@ -287,7 +290,7 @@ The application can be deployed to various cloud platforms. Here are some common
 
 1. Install the EB CLI:
    ```bash
-   pip install awsebcli
+   uv pip install awsebcli
    ```
 
 2. Initialize EB application:

--- a/README.zh.md
+++ b/README.zh.md
@@ -169,8 +169,11 @@ cd tavily-company-research
 python -m venv .venv
 source .venv/bin/activate
 
-# 安装Python依赖
-pip install -r requirements.txt
+# 安装 uv 包管理器
+curl -Ls https://astral.sh/uv/install.sh | bash
+
+# 使用 uv 安装 Python 依赖
+uv pip install -r requirements.txt
 ```
 
 3. 安装前端依赖：
@@ -261,7 +264,7 @@ npm run dev
    **选项2：使用Uvicorn的FastAPI**
    ```bash
    # 如果尚未安装，安装uvicorn
-   pip install uvicorn
+   uv pip install uvicorn
 
    # 使用热重载运行FastAPI应用
    uvicorn application:app --reload --port 8000
@@ -287,7 +290,7 @@ npm run dev
 
 1. 安装EB CLI：
    ```bash
-   pip install awsebcli
+   uv pip install awsebcli
    ```
 
 2. 初始化EB应用：

--- a/setup.sh
+++ b/setup.sh
@@ -47,6 +47,21 @@ else
     exit 1
 fi
 
+# Check if uv is installed
+echo -e "\n${BLUE}Checking for 'uv' package manager...${NC}"
+if command -v uv >/dev/null 2>&1; then
+    echo -e "${GREEN}✓ uv is installed${NC}"
+else
+    echo -e "${BLUE}Installing uv...${NC}"
+    curl -Ls https://astral.sh/uv/install.sh | bash
+    if command -v uv >/dev/null 2>&1; then
+        echo -e "${GREEN}✓ uv installed${NC}"
+    else
+        echo "❌ Failed to install uv. Please install it manually from https://github.com/astral-sh/uv"
+        exit 1
+    fi
+fi
+
 # Ask about virtual environment
 echo -e "\n${BLUE}Would you like to set up a Python virtual environment? (Recommended) [Y/n]${NC}"
 read -r use_venv
@@ -60,7 +75,7 @@ if [[ $use_venv =~ ^[Yy]$ ]]; then
     
     # Install Python dependencies in venv
     echo -e "\n${BLUE}Installing Python dependencies in virtual environment...${NC}"
-    pip install -r requirements.txt
+    uv pip install -r requirements.txt
     echo -e "${GREEN}✓ Python dependencies installed${NC}"
 else
     # Prompt for global installation
@@ -70,12 +85,12 @@ else
 
     if [[ $install_global =~ ^[Yy]$ ]]; then
         echo -e "\n${BLUE}Installing Python dependencies globally...${NC}"
-        pip3 install -r requirements.txt
+        uv pip install -r requirements.txt
         echo -e "${GREEN}✓ Python dependencies installed${NC}"
         echo -e "${BLUE}Note: Dependencies have been installed in your global Python environment${NC}"
     else
         echo -e "${BLUE}Skipping Python dependency installation. You'll need to install them manually later.${NC}"
-        echo -e "${BLUE}You can do this by running: pip install -r requirements.txt${NC}"
+        echo -e "${BLUE}You can do this by running: uv pip install -r requirements.txt${NC}"
     fi
 fi
 


### PR DESCRIPTION
## Summary
- install Python requirements with uv
- update setup script to install and use uv
- document uv usage in README (English, Chinese, French and Spanish)
- install uv inside Docker builds

## Testing
- `bash -n setup.sh`
- `python -m py_compile $(git ls-files '*.py')`
