### PR TITLE
Add uv package manager instructions

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -139,7 +139,7 @@ chmod +x setup.sh
 ./setup.sh
 ```
 
-El script de instalación hará lo siguiente:
+El script de instalación hará lo siguiente (usará `uv` automáticamente si está instalado):
 - Verificar las versiones requeridas de Python y Node.js
 - Opcionalmente crear un entorno virtual de Python (recomendado)
 - Instalar todas las dependencias (Python y Node.js)
@@ -165,11 +165,18 @@ cd tavily-company-research
 2. Instalar dependencias de backend:
 ```bash
 # Opcional: Crear y activar entorno virtual
-python -m venv .venv
+curl -Ls https://astral.sh/uv/install.sh | sh
+
+# Crear y activar un entorno virtual con uv
+uv venv .venv
 source .venv/bin/activate
 
 # Instalar dependencias de Python
-pip install -r requirements.txt
+uv pip install -r requirements.txt
+
+# Alternativamente, puedes usar las herramientas estándar de Python:
+# python -m venv .venv
+# pip install -r requirements.txt
 ```
 
 3. Instalar dependencias de frontend:

--- a/README.fr.md
+++ b/README.fr.md
@@ -126,7 +126,7 @@ La plateforme implémente un système de communication en temps réel basé sur 
 
 ### Configuration Rapide (Recommandée)
 
-La façon la plus simple de commencer est d'utiliser le script de configuration :
+La façon la plus simple de commencer est d'utiliser le script de configuration (il utilise `uv` automatiquement s'il est disponible) :
 
 1. Clonez le dépôt :
 ```bash
@@ -165,12 +165,19 @@ cd tavily-company-research
 
 2. Installez les dépendances backend :
 ```bash
-# Optionnel : Créez et activez un environnement virtuel
-python -m venv .venv
+# Optionnel : installez le gestionnaire de paquets `uv`
+curl -Ls https://astral.sh/uv/install.sh | sh
+
+# Créez et activez un environnement virtuel avec uv
+uv venv .venv
 source .venv/bin/activate
 
 # Installez les dépendances Python
-pip install -r requirements.txt
+uv pip install -r requirements.txt
+
+# Vous pouvez également utiliser les outils Python standards :
+# python -m venv .venv
+# pip install -r requirements.txt
 ```
 
 3. Installez les dépendances frontend :

--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ The platform implements a WebSocket-based real-time communication system:
 
 ### Quick Setup (Recommended)
 
-The easiest way to get started is using the setup script:
+The easiest way to get started is using the setup script (it will use the
+[`uv`](https://github.com/astral-sh/uv) package manager automatically if
+available):
 
 1. Clone the repository:
 ```bash
@@ -165,12 +167,19 @@ cd tavily-company-research
 
 2. Install backend dependencies:
 ```bash
-# Optional: Create and activate virtual environment
-python -m venv .venv
+# Optional: Install the `uv` package manager for faster installs
+curl -Ls https://astral.sh/uv/install.sh | sh
+
+# Create and activate a virtual environment (using uv)
+uv venv .venv
 source .venv/bin/activate
 
 # Install Python dependencies
-pip install -r requirements.txt
+uv pip install -r requirements.txt
+
+# Alternatively, you can use the standard Python tools:
+# python -m venv .venv
+# pip install -r requirements.txt
 ```
 
 3. Install frontend dependencies:

--- a/README.zh.md
+++ b/README.zh.md
@@ -140,7 +140,7 @@ chmod +x setup.sh
 ./setup.sh
 ```
 
-安装脚本将：
+安装脚本将（如果检测到 `uv` 会自动使用）：
 - 检查所需的Python和Node.js版本
 - 可选创建Python虚拟环境（推荐）
 - 安装所有依赖（Python和Node.js）
@@ -165,12 +165,19 @@ cd tavily-company-research
 
 2. 安装后端依赖：
 ```bash
-# 可选：创建并激活虚拟环境
-python -m venv .venv
+# 可选：安装 `uv` 包管理器，加快依赖安装
+curl -Ls https://astral.sh/uv/install.sh | sh
+
+# 创建并激活使用 uv 的虚拟环境
+uv venv .venv
 source .venv/bin/activate
 
-# 安装Python依赖
-pip install -r requirements.txt
+# 安装 Python 依赖
+uv pip install -r requirements.txt
+
+# 也可以使用标准的 Python 工具：
+# python -m venv .venv
+# pip install -r requirements.txt
 ```
 
 3. 安装前端依赖：

--- a/setup.sh
+++ b/setup.sh
@@ -47,20 +47,39 @@ else
     exit 1
 fi
 
+# Detect uv package manager
+if command -v uv >/dev/null 2>&1; then
+    uv_available=true
+else
+    uv_available=false
+fi
+
 # Ask about virtual environment
 echo -e "\n${BLUE}Would you like to set up a Python virtual environment? (Recommended) [Y/n]${NC}"
 read -r use_venv
 use_venv=${use_venv:-Y}
 
+if [ "$uv_available" = true ]; then
+    echo -e "${BLUE}Using uv for dependency management${NC}"
+fi
+
 if [[ $use_venv =~ ^[Yy]$ ]]; then
     echo -e "\n${BLUE}Setting up Python virtual environment...${NC}"
-    python3 -m venv .venv
+    if [ "$uv_available" = true ]; then
+        uv venv .venv
+    else
+        python3 -m venv .venv
+    fi
     source .venv/bin/activate
     echo -e "${GREEN}✓ Virtual environment created and activated${NC}"
-    
+
     # Install Python dependencies in venv
     echo -e "\n${BLUE}Installing Python dependencies in virtual environment...${NC}"
-    pip install -r requirements.txt
+    if [ "$uv_available" = true ]; then
+        uv pip install -r requirements.txt
+    else
+        pip install -r requirements.txt
+    fi
     echo -e "${GREEN}✓ Python dependencies installed${NC}"
 else
     # Prompt for global installation
@@ -70,12 +89,20 @@ else
 
     if [[ $install_global =~ ^[Yy]$ ]]; then
         echo -e "\n${BLUE}Installing Python dependencies globally...${NC}"
-        pip3 install -r requirements.txt
+        if [ "$uv_available" = true ]; then
+            uv pip install -r requirements.txt
+        else
+            pip3 install -r requirements.txt
+        fi
         echo -e "${GREEN}✓ Python dependencies installed${NC}"
         echo -e "${BLUE}Note: Dependencies have been installed in your global Python environment${NC}"
     else
         echo -e "${BLUE}Skipping Python dependency installation. You'll need to install them manually later.${NC}"
-        echo -e "${BLUE}You can do this by running: pip install -r requirements.txt${NC}"
+        if [ "$uv_available" = true ]; then
+            echo -e "${BLUE}You can do this by running: uv pip install -r requirements.txt${NC}"
+        else
+            echo -e "${BLUE}You can do this by running: pip install -r requirements.txt${NC}"
+        fi
     fi
 fi
 


### PR DESCRIPTION
## Summary
- mention `uv` usage in quick setup instructions
- document using `uv` in manual setup across all READMEs
- add optional `uv` integration in setup script

## Testing
- `pytest -q` *(fails: command not found)*