### PR TITLE
Use uv for all Python commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,12 @@ RUN npm run build
 # Stage 2: Build Backend
 FROM python:3.11-slim AS backend-builder
 WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -Ls https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:$PATH"
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN uv pip install --no-cache-dir -r requirements.txt
 
 # Stage 3: Final Image
 FROM python:3.11-slim
@@ -20,6 +24,8 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
+RUN curl -Ls https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:$PATH"
 
 # Copy backend
 COPY --from=backend-builder /usr/local/lib/python3.11/site-packages/ /usr/local/lib/python3.11/site-packages/
@@ -45,4 +51,4 @@ RUN chown -R appuser:appuser /app
 USER appuser
 
 # Start command
-CMD ["python", "-m", "uvicorn", "application:app", "--host", "0.0.0.0", "--port", "8000"] 
+CMD ["uv", "run", "python", "-m", "uvicorn", "application:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.es.md
+++ b/README.es.md
@@ -238,11 +238,11 @@ docker compose down && docker compose up
 
 1. Iniciar el servidor de backend (elige una opción):
 ```bash
-# Opción 1: Módulo Python Directo
-python -m application.py
+# Opción 1: Módulo Python Directo (usando uv)
+uv run python -m application.py
 
 # Opción 2: FastAPI con Uvicorn
-uvicorn application:app --reload --port 8000
+uv run uvicorn application:app --reload --port 8000
 ```
 
 2. En una nueva terminal, iniciar el frontend:
@@ -259,18 +259,18 @@ npm run dev
 
 1. Iniciar el servidor de backend (elige una opción):
 
-   **Opción 1: Módulo Python Directo**
+   **Opción 1: Módulo Python Directo (usando uv)**
    ```bash
-   python -m application.py
+   uv run python -m application.py
    ```
 
    **Opción 2: FastAPI con Uvicorn**
    ```bash
    # Instalar uvicorn si aún no está instalado
-   pip install uvicorn
+   uv pip install uvicorn
 
    # Ejecutar la aplicación FastAPI con recarga automática
-   uvicorn application:app --reload --port 8000
+   uv run uvicorn application:app --reload --port 8000
    ```
 
    El backend estará disponible en:
@@ -293,7 +293,7 @@ La aplicación puede desplegarse en varias plataformas en la nube. Aquí hay alg
 
 1. Instalar el EB CLI:
    ```bash
-   pip install awsebcli
+   uv pip install awsebcli
    ```
 
 2. Inicializar la aplicación EB:

--- a/README.fr.md
+++ b/README.fr.md
@@ -239,11 +239,11 @@ docker compose down && docker compose up
 
 1. Démarrez le serveur backend (choisissez une option) :
 ```bash
-# Option 1 : Module Python Direct
-python -m application.py
+# Option 1 : Module Python Direct (avec uv)
+uv run python -m application.py
 
 # Option 2 : FastAPI avec Uvicorn
-uvicorn application:app --reload --port 8000
+uv run uvicorn application:app --reload --port 8000
 ```
 
 2. Dans un nouveau terminal, démarrez le frontend :
@@ -260,18 +260,18 @@ npm run dev
 
 1. Démarrez le serveur backend (choisissez une option) :
 
-   **Option 1 : Module Python Direct**
+   **Option 1 : Module Python Direct (avec uv)**
    ```bash
-   python -m application.py
+   uv run python -m application.py
    ```
 
    **Option 2 : FastAPI avec Uvicorn**
    ```bash
    # Installez uvicorn si ce n'est pas déjà fait
-   pip install uvicorn
+   uv pip install uvicorn
 
    # Exécutez l'application FastAPI avec rechargement à chaud
-   uvicorn application:app --reload --port 8000
+   uv run uvicorn application:app --reload --port 8000
    ```
 
    Le backend sera disponible sur :
@@ -294,7 +294,7 @@ L'application peut être déployée sur diverses plateformes cloud. Voici quelqu
 
 1. Installez l'EB CLI :
    ```bash
-   pip install awsebcli
+   uv pip install awsebcli
    ```
 
 2. Initialisez l'application EB :

--- a/README.md
+++ b/README.md
@@ -241,11 +241,11 @@ docker compose down && docker compose up
 
 1. Start the backend server (choose one):
 ```bash
-# Option 1: Direct Python Module
-python -m application.py
+# Option 1: Direct Python Module (using uv)
+uv run python -m application.py
 
 # Option 2: FastAPI with Uvicorn
-uvicorn application:app --reload --port 8000
+uv run uvicorn application:app --reload --port 8000
 ```
 
 2. In a new terminal, start the frontend:
@@ -262,18 +262,18 @@ npm run dev
 
 1. Start the backend server (choose one option):
 
-   **Option 1: Direct Python Module**
+   **Option 1: Direct Python Module (using uv)**
    ```bash
-   python -m application.py
+   uv run python -m application.py
    ```
 
    **Option 2: FastAPI with Uvicorn**
    ```bash
    # Install uvicorn if not already installed
-   pip install uvicorn
+   uv pip install uvicorn
 
    # Run the FastAPI application with hot reload
-   uvicorn application:app --reload --port 8000
+   uv run uvicorn application:app --reload --port 8000
    ```
 
    The backend will be available at:
@@ -296,7 +296,7 @@ The application can be deployed to various cloud platforms. Here are some common
 
 1. Install the EB CLI:
    ```bash
-   pip install awsebcli
+   uv pip install awsebcli
    ```
 
 2. Initialize EB application:

--- a/README.zh.md
+++ b/README.zh.md
@@ -239,11 +239,11 @@ docker compose down && docker compose up
 
 1. 启动后端服务器（选择一种方式）：
 ```bash
-# 选项1：直接Python模块
-python -m application.py
+# 选项1：直接Python模块（使用 uv）
+uv run python -m application.py
 
 # 选项2：使用Uvicorn的FastAPI
-uvicorn application:app --reload --port 8000
+uv run uvicorn application:app --reload --port 8000
 ```
 
 2. 在新终端中启动前端：
@@ -260,18 +260,18 @@ npm run dev
 
 1. 启动后端服务器（选择一个选项）：
 
-   **选项1：直接Python模块**
+   **选项1：直接Python模块（使用 uv）**
    ```bash
-   python -m application.py
+   uv run python -m application.py
    ```
 
    **选项2：使用Uvicorn的FastAPI**
    ```bash
    # 如果尚未安装，安装uvicorn
-   pip install uvicorn
+   uv pip install uvicorn
 
    # 使用热重载运行FastAPI应用
-   uvicorn application:app --reload --port 8000
+   uv run uvicorn application:app --reload --port 8000
    ```
 
    后端将在以下位置可用：
@@ -294,7 +294,7 @@ npm run dev
 
 1. 安装EB CLI：
    ```bash
-   pip install awsebcli
+   uv pip install awsebcli
    ```
 
 2. 初始化EB应用：

--- a/setup.sh
+++ b/setup.sh
@@ -6,29 +6,20 @@ GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-# Version comparison function
+# Version comparison function (for Node check)
 version_compare() {
     echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'
 }
 
 echo -e "${BOLD}🚀 Welcome to the Agentic Company Researcher Setup!${NC}\n"
 
-# Check if Python 3.11+ is installed
-echo -e "${BLUE}Checking Python version...${NC}"
-if command -v python3 >/dev/null 2>&1; then
-    python_version=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
-    if [ "$(version_compare "$python_version")" -ge "$(version_compare "3.11")" ]; then
-        echo -e "${GREEN}✓ Python $python_version is installed${NC}"
-    else
-        echo "❌ Python 3.11 or higher is required. Current version: $python_version"
-        echo "Please install Python 3.11 or higher from https://www.python.org/downloads/"
-        exit 1
-    fi
-else
-    echo "❌ Python 3 is not installed"
-    echo "Please install Python 3.11 or higher from https://www.python.org/downloads/"
+# Ensure uv package manager is available
+if ! command -v uv >/dev/null 2>&1; then
+    echo "❌ uv is required but not installed."
+    echo "Install uv from https://astral.sh/uv/"
     exit 1
 fi
+echo -e "${BLUE}Using uv for Python execution${NC}"
 
 # Check if Node.js 18+ is installed
 echo -e "\n${BLUE}Checking Node.js version...${NC}"
@@ -47,39 +38,21 @@ else
     exit 1
 fi
 
-# Detect uv package manager
-if command -v uv >/dev/null 2>&1; then
-    uv_available=true
-else
-    uv_available=false
-fi
-
 # Ask about virtual environment
 echo -e "\n${BLUE}Would you like to set up a Python virtual environment? (Recommended) [Y/n]${NC}"
 read -r use_venv
 use_venv=${use_venv:-Y}
-
-if [ "$uv_available" = true ]; then
-    echo -e "${BLUE}Using uv for dependency management${NC}"
-fi
+echo -e "${BLUE}Using uv for dependency management${NC}"
 
 if [[ $use_venv =~ ^[Yy]$ ]]; then
     echo -e "\n${BLUE}Setting up Python virtual environment...${NC}"
-    if [ "$uv_available" = true ]; then
-        uv venv .venv
-    else
-        python3 -m venv .venv
-    fi
+    uv venv .venv
     source .venv/bin/activate
     echo -e "${GREEN}✓ Virtual environment created and activated${NC}"
 
     # Install Python dependencies in venv
     echo -e "\n${BLUE}Installing Python dependencies in virtual environment...${NC}"
-    if [ "$uv_available" = true ]; then
-        uv pip install -r requirements.txt
-    else
-        pip install -r requirements.txt
-    fi
+    uv pip install -r requirements.txt
     echo -e "${GREEN}✓ Python dependencies installed${NC}"
 else
     # Prompt for global installation
@@ -89,20 +62,12 @@ else
 
     if [[ $install_global =~ ^[Yy]$ ]]; then
         echo -e "\n${BLUE}Installing Python dependencies globally...${NC}"
-        if [ "$uv_available" = true ]; then
-            uv pip install -r requirements.txt
-        else
-            pip3 install -r requirements.txt
-        fi
+        uv pip install -r requirements.txt
         echo -e "${GREEN}✓ Python dependencies installed${NC}"
         echo -e "${BLUE}Note: Dependencies have been installed in your global Python environment${NC}"
     else
         echo -e "${BLUE}Skipping Python dependency installation. You'll need to install them manually later.${NC}"
-        if [ "$uv_available" = true ]; then
-            echo -e "${BLUE}You can do this by running: uv pip install -r requirements.txt${NC}"
-        else
-            echo -e "${BLUE}You can do this by running: pip install -r requirements.txt${NC}"
-        fi
+        echo -e "${BLUE}You can do this by running: uv pip install -r requirements.txt${NC}"
     fi
 fi
 
@@ -172,17 +137,17 @@ start_servers=${start_servers:-Y}
 
 if [[ $start_servers =~ ^[Yy]$ ]]; then
     echo -e "\n${BLUE}Choose backend server option:${NC}"
-    echo "1) python -m application.py"
-    echo "2) uvicorn application:app --reload --port 8000"
+    echo "1) uv run python -m application.py"
+    echo "2) uv run uvicorn application:app --reload --port 8000"
     read -r backend_choice
 
     # Start backend server in background
     if [ "$backend_choice" = "1" ]; then
-        echo -e "\n${GREEN}Starting backend server with python...${NC}"
-        python -m application.py &
+        echo -e "\n${GREEN}Starting backend server with uv...${NC}"
+        uv run python -m application.py &
     else
         echo -e "\n${GREEN}Starting backend server with uvicorn...${NC}"
-        uvicorn application:app --reload --port 8000 &
+        uv run uvicorn application:app --reload --port 8000 &
     fi
     
     # Store backend PID
@@ -210,8 +175,8 @@ if [[ $start_servers =~ ^[Yy]$ ]]; then
 else
     echo -e "\n${BOLD}To start the application manually:${NC}"
     echo -e "\n1. Start the backend server (choose one):"
-    echo "   Option 1: python -m application.py"
-    echo "   Option 2: uvicorn application:app --reload --port 8000"
+    echo "   Option 1: uv run python -m application.py"
+    echo "   Option 2: uv run uvicorn application:app --reload --port 8000"
     echo -e "\n2. In a new terminal, start the frontend:"
     echo "   cd ui"
     echo "   npm run dev"


### PR DESCRIPTION
## Summary
- replace python commands with `uv` in multilingual READMEs
- install and use `uv` in Dockerfile
- update `setup.sh` to require `uv` and run backend via `uv`

## Testing
- `pytest -q` *(fails: command not found)*