### PR TITLE
Add Japanese localization

### DIFF
--- a/backend/nodes/briefing.py
+++ b/backend/nodes/briefing.py
@@ -44,10 +44,10 @@ class Briefing:
                 )
 
         prompts = {
-            'company': f"""Create a focused company briefing for {company}, a {industry} company based in {hq_location}.
-Key requirements:
-1. Start with: "{company} is a [what] that [does what] for [whom]"
-2. Structure using these exact headers and bullet points:
+            'company': f"""{company} は日本の {industry} 企業で、本社は {hq_location} にあります。次の形式で企業ブリーフィングを作成してください。
+主な要件:
+1. 最初に「{company} は [何をする企業] で、[誰のためのもの]」と1文で述べる
+2. 以下の見出しと箇条書きを使用する:
 
 ### Core Product/Service
 * List distinct products/features
@@ -70,14 +70,14 @@ Key requirements:
 * Discuss product / service pricing
 * List distribution channels
 
-3. Each bullet must be a single, complete fact
-4. Never mention "no information found" or "no data available"
-5. No paragraphs, only bullet points
-6. Provide only the briefing. No explanations or commentary.""",
+3. 箇条書きは1項目につき1事実とする
+4. "情報が見つからない" などは記載しない
+5. 段落ではなく箇条書きのみを使用
+6. ブリーフィングのみを返答し、解説やコメントは不要""",
 
-            'industry': f"""Create a focused industry briefing for {company}, a {industry} company based in {hq_location}.
-Key requirements:
-1. Structure using these exact headers and bullet points:
+            'industry': f"""{company} は日本の {industry} 企業で、本社は {hq_location} にあります。以下の形式で業界ブリーフィングを作成してください。
+主な要件:
+1. 次の見出しと箇条書きを使用する:
 
 ### Market Overview
 * State {company}'s exact market segment
@@ -96,14 +96,14 @@ Key requirements:
 ### Market Challenges
 • List specific verified challenges
 
-2. Each bullet must be a single, complete news event.
-3. No paragraphs, only bullet points
-4. Never mention "no information found" or "no data available"
-5. Provide only the briefing. No explanation.""",
+2. 箇条書きはそれぞれ完結した事実とする
+3. 段落ではなく箇条書きのみを使用
+4. "情報が見つからない" などは記載しない
+5. ブリーフィングのみを返答する""",
 
-            'financial': f"""Create a focused financial briefing for {company}, a {industry} company based in {hq_location}.
-Key requirements:
-1. Structure using these headers and bullet points:
+            'financial': f"""{company} は日本の {industry} 企業で、本社は {hq_location} にあります。以下の形式で財務ブリーフィングを作成してください。
+主な要件:
+1. 次の見出しと箇条書きを使用する:
 
 ### Funding & Investment
 * Total funding amount with date
@@ -113,16 +113,16 @@ Key requirements:
 ### Revenue Model
 * Discuss product / service pricing if applicable
 
-2. Include specific numbers when possible
-3. No paragraphs, only bullet points
-4. Never mention "no information found" or "no data available"
-5. NEVER repeat the same round of funding multiple times. ALWAYS assume that multiple funding rounds in the same month are the same round.
-6. NEVER include a range of funding amounts. Use your best judgement to determine the exact amount based on the information provided.
-6. Provide only the briefing. No explanation or commentary.""",
+2. 可能であれば具体的な数値を含める
+3. 段落ではなく箇条書きのみを使用
+4. "情報が見つからない" などは記載しない
+5. 同じ月の複数の資金調達は同一ラウンドとみなす
+6. 金額の幅は提示せず、最も適切と思われる額を記載する
+6. ブリーフィングのみを返答し、解説やコメントは不要""",
 
-            'news': f"""Create a focused news briefing for {company}, a {industry} company based in {hq_location}.
-Key requirements:
-1. Structure into these categories using bullet points:
+            'news': f"""{company} は日本の {industry} 企業で、本社は {hq_location} にあります。以下の形式でニュースブリーフィングを作成してください。
+主な要件:
+1. 次のカテゴリに分けて箇条書きを使用する:
 
 ### Major Announcements
 * Product / service launches
@@ -136,11 +136,11 @@ Key requirements:
 * Awards
 * Press coverage
 
-2. Sort newest to oldest
-3. One event per bullet point
-4. Do not mention "no information found" or "no data available"
-5. Never use ### headers, only bullet points
-6. Provide only the briefing. Do not provide explanations or commentary.""",
+2. 新しいものから順に並べる
+3. 1行につき1つの出来事とする
+4. "情報が見つからない" などは記載しない
+5. ### 見出しを使わず箇条書きのみ
+6. ブリーフィングのみを返答し、解説やコメントは不要""",
         }
         
         # Normalize docs to a list of (url, doc) tuples
@@ -169,9 +169,9 @@ Key requirements:
                 break
         
         separator = "\n" + "-" * 40 + "\n"
-        prompt = f"""{prompts.get(category, 'Create a focused, informative and insightful research briefing on the company: {company} in the {industry} industry based on the provided documents.')}
+        prompt = f"""{prompts.get(category, '{company} に関する詳細で有益な日本語のブリーフィングを作成してください。業界は {industry} で、本社は {hq_location} にあります。')}
 
-Analyze the following documents and extract key information. Provide only the briefing, no explanations or commentary:
+以下の文書を分析し、主要な情報を抽出してください。ブリーフィングのみを返答し、解説やコメントは不要です:
 
 {separator}{separator.join(doc_texts)}{separator}
 

--- a/backend/nodes/editor.py
+++ b/backend/nodes/editor.py
@@ -217,35 +217,33 @@ class Editor:
         industry = self.context["industry"]
         hq_location = self.context["hq_location"]
         
-        prompt = f"""You are compiling a comprehensive research report about {company}.
-
-Compiled briefings:
+        prompt = f"""{company} に関する包括的な調査レポートを作成してください。以下は各セクションのブリーフィングです:
 {combined_content}
 
-Create a comprehensive and focused report on {company}, a {industry} company headquartered in {hq_location} that:
-1. Integrates information from all sections into a cohesive non-repetitive narrative
-2. Maintains important details from each section
-3. Logically organizes information and removes transitional commentary / explanations
-4. Uses clear section headers and structure
+{company} は日本の {industry} 企業で、本社は {hq_location} にあります。次の点に留意してレポートをまとめてください。
+1. すべてのセクションの情報を統合し、重複を避ける
+2. 各セクションの重要な内容を保持する
+3. 論理的に整理し、不要なつなぎの説明を省く
+4. 明確なセクション見出しと構成を使用する
 
-Formatting rules:
-Strictly enforce this EXACT document structure:
+書式ルール:
+以下のドキュメント構成を厳密に守ってください。
 
-# {company} Research Report
+# {company} 調査レポート
 
-## Company Overview
+## 会社概要
 [Company content with ### subsections]
 
-## Industry Overview
+## 業界概要
 [Industry content with ### subsections]
 
-## Financial Overview
+## 財務概要
 [Financial content with ### subsections]
 
-## News
+## ニュース
 [News content with ### subsections]
 
-Return the report in clean markdown format. No explanations or commentary."""
+レポートはマークダウン形式で返してください。解説やコメントは不要です。"""
         
         try:
             response = await self.openai_client.chat.completions.create(
@@ -253,7 +251,7 @@ Return the report in clean markdown format. No explanations or commentary."""
                 messages=[
                     {
                         "role": "system",
-                        "content": "You are an expert report editor that compiles research briefings into comprehensive company reports."
+                        "content": "あなたはブリーフィングを統合して詳細なレポートを作成する専門編集者です。"
                     },
                     {
                         "role": "user",
@@ -281,17 +279,17 @@ Return the report in clean markdown format. No explanations or commentary."""
         industry = self.context["industry"]
         hq_location = self.context["hq_location"]
         
-        prompt = f"""You are an expert briefing editor. You are given a report on {company}.
+        prompt = f"""あなたはブリーフィング編集の専門家です。以下は {company} に関するレポートです。
 
-Current report:
+現在のレポート:
 {content}
 
-1. Remove redundant or repetitive information
-2. Remove information that is not relevant to {company}, the {industry} company headquartered in {hq_location}.
-3. Remove sections lacking substantial content
-4. Remove any meta-commentary (e.g. "Here is the news...")
+1. 重複した情報を削除する
+2. {hq_location} に本社を置く日本の {industry} 企業 {company} に関係のない情報を除外する
+3. 内容の薄いセクションを削除する
+4. "ここにニュースがあります" のようなメタ的なコメントを除去する
 
-Strictly enforce this EXACT document structure:
+次のドキュメント構成を厳密に守ってください:
 
 ## Company Overview
 [Company content with ### subsections]
@@ -308,26 +306,26 @@ Strictly enforce this EXACT document structure:
 ## References
 [References in MLA format - PRESERVE EXACTLY AS PROVIDED]
 
-Critical rules:
-1. The document MUST start with "# {company} Research Report"
-2. The document MUST ONLY use these exact ## headers in this order:
-   - ## Company Overview
-   - ## Industry Overview
-   - ## Financial Overview
-   - ## News
+重要なルール:
+1. ドキュメントは必ず "# {company} 調査レポート" から始める
+2. 使用できる ## 見出しは以下の順序のみ:
+   - ## 会社概要
+   - ## 業界概要
+   - ## 財務概要
+   - ## ニュース
    - ## References
-3. NO OTHER ## HEADERS ARE ALLOWED
-4. Use ### for subsections in Company/Industry/Financial sections
-5. News section should only use bullet points (*), never headers
-6. Never use code blocks (```)
-7. Never use more than one blank line between sections
-8. Format all bullet points with *
-9. Add one blank line before and after each section/list
-10. DO NOT CHANGE the format of the references section
+3. 他の ## 見出しは使用不可
+4. 会社・業界・財務の各セクションでは ### を使う
+5. ニュースセクションは箇条書き(*)のみで見出しを使わない
+6. コードブロック(```)は使用しない
+7. セクション間の空行は1行まで
+8. すべての箇条書きは * で始める
+9. 各セクション/リストの前後には1行の空行を入れる
+10. References セクションの形式は変更しない
 
-Return the polished report in flawless markdown format. No explanation.
+整形済みのレポートをマークダウン形式で返してください。解説は不要です。
 
-Return the cleaned report in flawless markdown format. No explanations or commentary."""
+最終的なレポートのみを返答し、コメントは不要です。"""
         
         try:
             response = await self.openai_client.chat.completions.create(
@@ -335,7 +333,7 @@ Return the cleaned report in flawless markdown format. No explanations or commen
                 messages=[
                     {
                         "role": "system",
-                        "content": "You are an expert markdown formatter that ensures consistent document structure."
+                        "content": "あなたは文書構造を整える専門的なMarkdownフォーマッターです。"
                     },
                     {
                         "role": "user",

--- a/backend/nodes/researchers/base.py
+++ b/backend/nodes/researchers/base.py
@@ -48,7 +48,7 @@ class BaseResearcher:
                 messages=[
                     {
                         "role": "system",
-                        "content": f"You are researching {company}, a company in the {industry} industry."
+                        "content": f"あなたは{industry}業界の日本の企業{company}について調査しています。"
                     },
                     {
                         "role": "user",
@@ -153,11 +153,12 @@ class BaseResearcher:
     def _format_query_prompt(self, prompt, company, hq, year):
         return f"""{prompt}
 
-        Important Guidelines:
-        - Focus ONLY on {company}-specific information
-        - Make queries very brief and to the point
-        - Provide exactly 4 search queries (one per line), with no hyphens or dashes
-        - DO NOT make assumptions about the industry - use only the provided industry information"""
+        この企業は日本の企業です。
+        重要なガイドライン:
+        - {company}に特化した情報のみに集中する
+        - クエリは簡潔にまとめる
+        - 検索クエリは4つだけ(各行1つ)、ハイフンやダッシュは使わない
+        - 業界について推測せず、提供された情報のみを使用する"""
 
     def _fallback_queries(self, company, year):
         return [
@@ -188,7 +189,9 @@ class BaseResearcher:
             search_params = {
                 "search_depth": "basic",
                 "include_raw_content": False,
-                "max_results": 5
+                "max_results": 5,
+                "search_lang": "ja",
+                "search_region": "jp"
             }
             
             if self.analyst_type == "news_analyst":
@@ -285,7 +288,9 @@ class BaseResearcher:
         search_params = {
             "search_depth": "basic",
             "include_raw_content": False,
-            "max_results": 5
+            "max_results": 5,
+            "search_lang": "ja",
+            "search_region": "jp"
         }
         
         if self.analyst_type == "news_analyst":

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Company Research</title>
+    <title>企業調査</title>
   </head>
   <body>
     <div id="root"></div>

--- a/ui/src/components/CurationExtraction.tsx
+++ b/ui/src/components/CurationExtraction.tsx
@@ -37,7 +37,7 @@ const CurationExtraction: React.FC<CurationExtractionProps> = ({
         onClick={onToggleExpand}
       >
         <h2 className="text-xl font-semibold text-gray-900">
-          Curation and Extraction
+          キュレーションと抽出
         </h2>
         <button className="text-gray-600 hover:text-gray-900 transition-colors">
           {isExpanded ? (
@@ -69,9 +69,9 @@ const CurationExtraction: React.FC<CurationExtractionProps> = ({
                   </div>
                   <div className="text-sm text-gray-600">
                     {counts ? (
-                      `selected from ${counts.total}`
+                      `${counts.total} 件中から選択`
                     ) : (
-                      "waiting..."
+                      "待機中..."
                     )}
                   </div>
                 </div>
@@ -83,7 +83,7 @@ const CurationExtraction: React.FC<CurationExtractionProps> = ({
 
       {!isExpanded && enrichmentCounts && (
         <div className="mt-2 text-sm text-gray-600">
-          {Object.values(enrichmentCounts).reduce((acc, curr) => acc + curr.enriched, 0)} documents enriched from {Object.values(enrichmentCounts).reduce((acc, curr) => acc + curr.total, 0)} total
+          {Object.values(enrichmentCounts).reduce((acc, curr) => acc + curr.enriched, 0)} 件が {Object.values(enrichmentCounts).reduce((acc, curr) => acc + curr.total, 0)} 件中で抽出されました
         </div>
       )}
     </div>

--- a/ui/src/components/ExamplePopup.tsx
+++ b/ui/src/components/ExamplePopup.tsx
@@ -102,7 +102,7 @@ const ExamplePopup: React.FC<ExamplePopupProps> = ({
     >
       <Sparkles className="h-4 w-4 text-blue-500 group-hover:text-blue-600 animate-pulse group-hover:animate-none group-hover:scale-110 transition-all" />
       <div>
-        <span className="text-sm font-medium text-gray-700 group-hover:text-gray-800 transition-colors">Try an example: </span>
+        <span className="text-sm font-medium text-gray-700 group-hover:text-gray-800 transition-colors">例を試す: </span>
         <span 
           className={`text-sm font-bold text-blue-600 group-hover:text-blue-700 transition-all inline-block
             ${isNameAnimating ? 'opacity-0 transform -translate-y-3 scale-95' : 'opacity-100 transform translate-y-0 scale-100'}`}

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -16,10 +16,10 @@ const Header: React.FC<HeaderProps> = ({ glassStyle }) => {
     <div className="relative mb-16">
       <div className="text-center pt-4">
         <h1 className="text-[48px] font-medium text-[#1a202c] font-['DM_Sans'] tracking-[-1px] leading-[52px] text-center mx-auto antialiased">
-          Company Research Agent
+          企業調査エージェント
         </h1>
         <p className="text-gray-600 text-lg font-['DM_Sans'] mt-4">
-          Conduct in-depth company diligence powered by Tavily
+          Tavily を活用した詳細な企業調査
         </p>
       </div>
       <div className="absolute top-0 right-0 flex items-center space-x-2">

--- a/ui/src/components/LocationInput.tsx
+++ b/ui/src/components/LocationInput.tsx
@@ -206,7 +206,7 @@ const LocationInput: React.FC<LocationInputProps> = ({ value, onChange, classNam
           }
         }}
         className={`${className} !font-['DM_Sans']`}
-        placeholder="City, Country"
+        placeholder="都市、国"
       />
     </div>
   );

--- a/ui/src/components/ResearchBriefings.tsx
+++ b/ui/src/components/ResearchBriefings.tsx
@@ -35,7 +35,7 @@ const ResearchBriefings: React.FC<ResearchBriefingsProps> = ({
         onClick={onToggleExpand}
       >
         <h2 className="text-xl font-semibold text-gray-900">
-          Research Briefings
+          調査ブリーフィング
         </h2>
         <button className="text-gray-600 hover:text-gray-900 transition-colors">
           {isExpanded ? (
@@ -72,7 +72,7 @@ const ResearchBriefings: React.FC<ResearchBriefingsProps> = ({
                   briefingStatus[category as keyof BriefingStatus]
                     ? 'text-[#468BFF]'
                     : 'text-gray-700 group-hover:text-gray-900'
-                }`}>{category}</h3>
+                }`>{({ company: '会社', industry: '業界', financial: '財務', news: 'ニュース' } as Record<string, string>)[category]}</h3>
                 {briefingStatus[category as keyof BriefingStatus] ? (
                   <CheckCircle2 className="h-4 w-4 text-[#468BFF] transition-all duration-300" />
                 ) : (
@@ -86,7 +86,7 @@ const ResearchBriefings: React.FC<ResearchBriefingsProps> = ({
 
       {!isExpanded && (
         <div className="mt-2 text-sm text-gray-600">
-          {Object.values(briefingStatus).filter(Boolean).length} of {Object.keys(briefingStatus).length} briefings completed
+          {Object.values(briefingStatus).filter(Boolean).length}/{Object.keys(briefingStatus).length} 件のブリーフィングが完了しました
         </div>
       )}
     </div>

--- a/ui/src/components/ResearchForm.tsx
+++ b/ui/src/components/ResearchForm.tsx
@@ -138,7 +138,7 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
                 htmlFor="companyName"
                 className="block text-base font-medium text-gray-700 mb-2.5 transition-all duration-200 group-hover:text-gray-900 font-['DM_Sans']"
               >
-                Company Name <span className="text-gray-900/70">*</span>
+                企業名 <span className="text-gray-900/70">*</span>
               </label>
               <div className="relative">
                 <div className="absolute inset-0 bg-gradient-to-r from-gray-50/0 via-gray-100/50 to-gray-50/0 opacity-0 group-hover:opacity-100 transition-opacity duration-500 rounded-lg"></div>
@@ -155,7 +155,7 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
                     }))
                   }
                   className={`${glassStyle.input} transition-all duration-300 focus:border-[#468BFF]/50 focus:ring-1 focus:ring-[#468BFF]/50 group-hover:border-[#468BFF]/30 bg-white/80 backdrop-blur-sm text-lg py-4 pl-12 font-['DM_Sans']`}
-                  placeholder="Enter company name"
+                  placeholder="企業名を入力"
                 />
               </div>
             </div>
@@ -166,7 +166,7 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
                 htmlFor="companyUrl"
                 className="block text-base font-medium text-gray-700 mb-2.5 transition-all duration-200 group-hover:text-gray-900 font-['DM_Sans']"
               >
-                Company URL
+                企業URL
               </label>
               <div className="relative">
                 <div className="absolute inset-0 bg-gradient-to-r from-gray-50/0 via-gray-100/50 to-gray-50/0 opacity-0 group-hover:opacity-100 transition-opacity duration-500 rounded-lg"></div>
@@ -182,7 +182,7 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
                     }))
                   }
                   className={`${glassStyle.input} transition-all duration-300 focus:border-[#468BFF]/50 focus:ring-1 focus:ring-[#468BFF]/50 group-hover:border-[#468BFF]/30 bg-white/80 backdrop-blur-sm text-lg py-4 pl-12 font-['DM_Sans']`}
-                  placeholder="example.com"
+                  placeholder="example.co.jp"
                 />
               </div>
             </div>
@@ -193,7 +193,7 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
                 htmlFor="companyHq"
                 className="block text-base font-medium text-gray-700 mb-2.5 transition-all duration-200 group-hover:text-gray-900 font-['DM_Sans']"
               >
-                Company HQ
+                本社所在地
               </label>
               <LocationInput
                 value={formData.companyHq}
@@ -213,7 +213,7 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
                 htmlFor="companyIndustry"
                 className="block text-base font-medium text-gray-700 mb-2.5 transition-all duration-200 group-hover:text-gray-900 font-['DM_Sans']"
               >
-                Company Industry
+                業界
               </label>
               <div className="relative">
                 <div className="absolute inset-0 bg-gradient-to-r from-gray-50/0 via-gray-100/50 to-gray-50/0 opacity-0 group-hover:opacity-100 transition-opacity duration-500 rounded-lg"></div>
@@ -229,7 +229,7 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
                     }))
                   }
                   className={`${glassStyle.input} transition-all duration-300 focus:border-[#468BFF]/50 focus:ring-1 focus:ring-[#468BFF]/50 group-hover:border-[#468BFF]/30 bg-white/80 backdrop-blur-sm text-lg py-4 pl-12 font-['DM_Sans']`}
-                  placeholder="e.g. Technology, Healthcare"
+                  placeholder="例: テクノロジー、ヘルスケア"
                 />
               </div>
             </div>
@@ -245,12 +245,12 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
               {isResearching ? (
                 <>
                   <Loader2 className="animate-spin -ml-1 mr-2 h-5 w-5 loader-icon" style={{ stroke: loaderColor }} />
-                  <span className="text-base font-medium text-gray-900/90">Researching...</span>
+                  <span className="text-base font-medium text-gray-900/90">調査中...</span>
                 </>
               ) : (
                 <>
                   <Search className="-ml-1 mr-2 h-5 w-5 text-gray-900/90" />
-                  <span className="text-base font-medium text-gray-900/90">Start Research</span>
+                  <span className="text-base font-medium text-gray-900/90">調査開始</span>
                 </>
               )}
             </div>

--- a/ui/src/components/ResearchQueries.tsx
+++ b/ui/src/components/ResearchQueries.tsx
@@ -22,7 +22,7 @@ const ResearchQueries: React.FC<ResearchQueriesProps> = ({
         onClick={onToggleExpand}
       >
         <h2 className="text-xl font-semibold text-gray-900">
-          Generated Research Queries
+          生成された調査クエリ
         </h2>
         <button className="text-gray-600 hover:text-gray-900 transition-colors">
           {isExpanded ? (
@@ -40,7 +40,7 @@ const ResearchQueries: React.FC<ResearchQueriesProps> = ({
           {['company', 'industry', 'financial', 'news'].map((category) => (
             <div key={category} className={`${glassStyle} rounded-xl p-3`}>
               <h3 className="text-base font-medium text-gray-900 mb-3 capitalize">
-                {category.charAt(0).toUpperCase() + category.slice(1)} Queries
+                {({ company: '会社', industry: '業界', financial: '財務', news: 'ニュース' } as Record<string, string>)[category]}クエリ
               </h3>
               <div className="space-y-2">
                 {/* Show streaming queries first */}
@@ -68,7 +68,7 @@ const ResearchQueries: React.FC<ResearchQueriesProps> = ({
       
       {!isExpanded && (
         <div className="mt-2 text-sm text-gray-600">
-          {queries.length} queries generated across {['company', 'industry', 'financial', 'news'].length} categories
+          {queries.length}件のクエリが{['company', 'industry', 'financial', 'news'].length}カテゴリで生成されました
         </div>
       )}
     </div>

--- a/ui/src/components/ResearchReport.tsx
+++ b/ui/src/components/ResearchReport.tsx
@@ -60,7 +60,7 @@ const ResearchReport: React.FC<ResearchReportProps> = ({
               {isGeneratingPdf ? (
                 <>
                   <Loader2 className="animate-spin h-5 w-5 mr-2" style={{ stroke: loaderColor }} />
-                  Generating PDF...
+                  PDFを生成中...
                 </>
               ) : (
                 <>
@@ -175,7 +175,7 @@ const ResearchReport: React.FC<ResearchReportProps> = ({
               ),
             }}
           >
-            {output.details.report || "No report available"}
+            {output.details.report || "レポートはありません"}
           </ReactMarkdown>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- translate frontend text to Japanese
- localize prompts for researchers, briefing, and editor
- specify Japanese language and region for Tavily search

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python -m py_compile backend/nodes/researchers/base.py backend/nodes/briefing.py backend/nodes/editor.py`