### PR TITLE
Add Japanese language support

### DIFF
--- a/application.py
+++ b/application.py
@@ -64,6 +64,7 @@ class ResearchRequest(BaseModel):
     company_url: str | None = None
     industry: str | None = None
     hq_location: str | None = None
+    language: str | None = "en"
 
 class PDFGenerationRequest(BaseModel):
     report_content: str
@@ -116,6 +117,7 @@ async def process_research(job_id: str, data: ResearchRequest):
             url=data.company_url,
             industry=data.industry,
             hq_location=data.hq_location,
+            language=data.language,
             websocket_manager=manager,
             job_id=job_id
         )

--- a/backend/classes/state.py
+++ b/backend/classes/state.py
@@ -7,6 +7,7 @@ class InputState(TypedDict, total=False):
     company_url: NotRequired[str]
     hq_location: NotRequired[str]
     industry: NotRequired[str]
+    language: NotRequired[str]
     websocket_manager: NotRequired[WebSocketManager]
     job_id: NotRequired[str]
 
@@ -28,3 +29,4 @@ class ResearchState(InputState):
     references: List[str]
     briefings: Dict[str, Any]
     report: str
+

--- a/backend/graph.py
+++ b/backend/graph.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 class Graph:
     def __init__(self, company=None, url=None, hq_location=None, industry=None,
-                 websocket_manager=None, job_id=None):
+                 language="en", websocket_manager=None, job_id=None):
         self.websocket_manager = websocket_manager
         self.job_id = job_id
         
@@ -27,6 +27,7 @@ class Graph:
             company_url=url,
             hq_location=hq_location,
             industry=industry,
+            language=language,
             websocket_manager=websocket_manager,
             job_id=job_id,
             messages=[

--- a/backend/nodes/briefing.py
+++ b/backend/nodes/briefing.py
@@ -27,6 +27,8 @@ class Briefing:
         company = context.get('company', 'Unknown')
         industry = context.get('industry', 'Unknown')
         hq_location = context.get('hq_location', 'Unknown')
+        language = context.get('language', 'en')
+        prefix = "回答は日本語でお願いします。" if language == 'ja' else ""
         logger.info(f"Generating {category} briefing for {company} using {len(docs)} documents")
 
         # Send category start status
@@ -44,7 +46,7 @@ class Briefing:
                 )
 
         prompts = {
-            'company': f"""Create a focused company briefing for {company}, a {industry} company based in {hq_location}.
+            'company': f"""{prefix}Create a focused company briefing for {company}, a {industry} company based in {hq_location}.
 Key requirements:
 1. Start with: "{company} is a [what] that [does what] for [whom]"
 2. Structure using these exact headers and bullet points:
@@ -75,7 +77,7 @@ Key requirements:
 5. No paragraphs, only bullet points
 6. Provide only the briefing. No explanations or commentary.""",
 
-            'industry': f"""Create a focused industry briefing for {company}, a {industry} company based in {hq_location}.
+            'industry': f"""{prefix}Create a focused industry briefing for {company}, a {industry} company based in {hq_location}.
 Key requirements:
 1. Structure using these exact headers and bullet points:
 
@@ -101,7 +103,7 @@ Key requirements:
 4. Never mention "no information found" or "no data available"
 5. Provide only the briefing. No explanation.""",
 
-            'financial': f"""Create a focused financial briefing for {company}, a {industry} company based in {hq_location}.
+            'financial': f"""{prefix}Create a focused financial briefing for {company}, a {industry} company based in {hq_location}.
 Key requirements:
 1. Structure using these headers and bullet points:
 
@@ -120,7 +122,7 @@ Key requirements:
 6. NEVER include a range of funding amounts. Use your best judgement to determine the exact amount based on the information provided.
 6. Provide only the briefing. No explanation or commentary.""",
 
-            'news': f"""Create a focused news briefing for {company}, a {industry} company based in {hq_location}.
+            'news': f"""{prefix}Create a focused news briefing for {company}, a {industry} company based in {hq_location}.
 Key requirements:
 1. Structure into these categories using bullet points:
 
@@ -222,6 +224,7 @@ Analyze the following documents and extract key information. Provide only the br
             "company": company,
             "industry": state.get('industry', 'Unknown'),
             "hq_location": state.get('hq_location', 'Unknown'),
+            "language": state.get('language', 'en'),
             "websocket_manager": websocket_manager,
             "job_id": job_id
         }

--- a/backend/nodes/editor.py
+++ b/backend/nodes/editor.py
@@ -24,7 +24,8 @@ class Editor:
         self.context = {
             "company": "Unknown Company",
             "industry": "Unknown",
-            "hq_location": "Unknown"
+            "hq_location": "Unknown",
+            "language": "en"
         }
 
     async def compile_briefings(self, state: ResearchState) -> ResearchState:
@@ -35,7 +36,8 @@ class Editor:
         self.context = {
             "company": company,
             "industry": state.get('industry', 'Unknown'),
-            "hq_location": state.get('hq_location', 'Unknown')
+            "hq_location": state.get('hq_location', 'Unknown'),
+            "language": state.get('language', 'en')
         }
         
         # Send initial compilation status
@@ -216,8 +218,12 @@ class Editor:
         company = self.context["company"]
         industry = self.context["industry"]
         hq_location = self.context["hq_location"]
+        language = self.context.get("language", "en")
+        prefix = "この内容は日本語で書き直してください。" if language == "ja" else ""
+        language = self.context.get("language", "en")
+        prefix = "レポートは日本語で作成してください。" if language == "ja" else ""
         
-        prompt = f"""You are compiling a comprehensive research report about {company}.
+        prompt = f"""{prefix}You are compiling a comprehensive research report about {company}.
 
 Compiled briefings:
 {combined_content}
@@ -281,7 +287,7 @@ Return the report in clean markdown format. No explanations or commentary."""
         industry = self.context["industry"]
         hq_location = self.context["hq_location"]
         
-        prompt = f"""You are an expert briefing editor. You are given a report on {company}.
+        prompt = f"""{prefix}You are an expert briefing editor. You are given a report on {company}.
 
 Current report:
 {content}

--- a/backend/nodes/grounding.py
+++ b/backend/nodes/grounding.py
@@ -127,6 +127,7 @@ class GroundingNode:
             "company_url": state.get('company_url'),
             "hq_location": state.get('hq_location'),
             "industry": state.get('industry'),
+            "language": state.get('language', 'en'),
             # Initialize research fields
             "messages": [AIMessage(content=msg)],
             "site_scrape": site_scrape,

--- a/backend/nodes/researchers/base.py
+++ b/backend/nodes/researchers/base.py
@@ -36,6 +36,7 @@ class BaseResearcher:
         company = state.get("company", "Unknown Company")
         industry = state.get("industry", "Unknown Industry")
         hq = state.get("hq", "Unknown HQ")
+        language = state.get("language", "en")
         current_year = datetime.now().year
         websocket_manager = state.get('websocket_manager')
         job_id = state.get('job_id')
@@ -48,11 +49,11 @@ class BaseResearcher:
                 messages=[
                     {
                         "role": "system",
-                        "content": f"You are researching {company}, a company in the {industry} industry."
+                        "content": f"You are researching {company}, a company in the {industry} industry. Respond in {'Japanese' if language == 'ja' else 'English'}."
                     },
                     {
                         "role": "user",
-                        "content": f"""Researching {company} on {datetime.now().strftime("%B %d, %Y")}.
+                        "content": f"""Researching {company} on {datetime.now().strftime('%B %d, %Y')}.
 {self._format_query_prompt(prompt, company, hq, current_year)}"""
                     }
                 ],

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -31,6 +31,7 @@ document.head.appendChild(dmSansStyleElement);
 function App() {
 
   const [isResearching, setIsResearching] = useState(false);
+  const [language, setLanguage] = useState<'en' | 'ja'>('en');
   const [status, setStatus] = useState<ResearchStatusType | null>(null);
   const [output, setOutput] = useState<ResearchOutput | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -626,6 +627,7 @@ function App() {
         company_url: formattedCompanyUrl,
         industry: formData.companyIndustry || undefined,
         hq_location: formData.companyHq || undefined,
+        language,
       };
 
       const response = await fetch(url, {
@@ -803,6 +805,7 @@ function App() {
           onToggleExpand={() => setIsQueriesExpanded(!isQueriesExpanded)}
           isResetting={isResetting}
           glassStyle={glassStyle.base}
+          language={language}
         />
       );
     }
@@ -824,14 +827,15 @@ function App() {
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_1px_1px,rgba(70,139,255,0.35)_1px,transparent_0)] bg-[length:24px_24px] bg-center"></div>
       <div className="max-w-5xl mx-auto space-y-8 relative">
         {/* Header Component */}
-        <Header glassStyle={glassStyle.card} />
+        <Header glassStyle={glassStyle.card} language={language} onLanguageChange={setLanguage} />
 
         {/* Form Section */}
-        <ResearchForm 
+        <ResearchForm
           onSubmit={handleFormSubmit}
           isResearching={isResearching}
           glassStyle={glassStyle}
           loaderColor={loaderColor}
+          language={language}
         />
 
         {/* Error Message */}

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { Github } from 'lucide-react';
+import { translations } from '../utils/translations';
 
 interface HeaderProps {
   glassStyle: string;
+  language: 'en' | 'ja';
+  onLanguageChange: (lang: 'en' | 'ja') => void;
 }
 
-const Header: React.FC<HeaderProps> = ({ glassStyle }) => {
+const Header: React.FC<HeaderProps> = ({ glassStyle, language, onLanguageChange }) => {
   const handleImageError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
     console.error('Failed to load Tavily logo');
     console.log('Image path:', e.currentTarget.src);
@@ -16,10 +19,10 @@ const Header: React.FC<HeaderProps> = ({ glassStyle }) => {
     <div className="relative mb-16">
       <div className="text-center pt-4">
         <h1 className="text-[48px] font-medium text-[#1a202c] font-['DM_Sans'] tracking-[-1px] leading-[52px] text-center mx-auto antialiased">
-          Company Research Agent
+          {translations[language].title}
         </h1>
         <p className="text-gray-600 text-lg font-['DM_Sans'] mt-4">
-          Conduct in-depth company diligence powered by Tavily
+          {translations[language].tagline}
         </p>
       </div>
       <div className="absolute top-0 right-0 flex items-center space-x-2">
@@ -52,18 +55,27 @@ const Header: React.FC<HeaderProps> = ({ glassStyle }) => {
           style={{ width: '40px', height: '40px', padding: '8px' }}
           aria-label="GitHub Profile"
         >
-          <Github 
-            style={{ 
-              width: '24px', 
+          <Github
+            style={{
+              width: '24px',
               height: '24px',
               display: 'block',
               margin: 'auto'
-            }} 
+            }}
           />
         </a>
+        <select
+          value={language}
+          onChange={(e) => onLanguageChange(e.target.value as 'en' | 'ja')}
+          className="border rounded p-1 text-sm"
+        >
+          <option value="en">EN</option>
+          <option value="ja">日本語</option>
+        </select>
       </div>
     </div>
   );
 };
 
 export default Header; 
+

--- a/ui/src/components/ResearchForm.tsx
+++ b/ui/src/components/ResearchForm.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
+import { translations } from '../utils/translations';
 import { Building2, Factory, Globe, Loader2, Search } from 'lucide-react';
 import LocationInput from './LocationInput';
 import ExamplePopup, { ExampleCompany } from './ExamplePopup';
@@ -18,13 +19,15 @@ interface ResearchFormProps {
     input: string;
   };
   loaderColor: string;
+  language: 'en' | 'ja';
 }
 
 const ResearchForm: React.FC<ResearchFormProps> = ({
   onSubmit,
   isResearching,
   glassStyle,
-  loaderColor
+  loaderColor,
+  language
 }) => {
   const [formData, setFormData] = useState<FormData>({
     companyName: "",
@@ -138,7 +141,7 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
                 htmlFor="companyName"
                 className="block text-base font-medium text-gray-700 mb-2.5 transition-all duration-200 group-hover:text-gray-900 font-['DM_Sans']"
               >
-                Company Name <span className="text-gray-900/70">*</span>
+                {translations[language].companyName} <span className="text-gray-900/70">*</span>
               </label>
               <div className="relative">
                 <div className="absolute inset-0 bg-gradient-to-r from-gray-50/0 via-gray-100/50 to-gray-50/0 opacity-0 group-hover:opacity-100 transition-opacity duration-500 rounded-lg"></div>
@@ -155,7 +158,7 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
                     }))
                   }
                   className={`${glassStyle.input} transition-all duration-300 focus:border-[#468BFF]/50 focus:ring-1 focus:ring-[#468BFF]/50 group-hover:border-[#468BFF]/30 bg-white/80 backdrop-blur-sm text-lg py-4 pl-12 font-['DM_Sans']`}
-                  placeholder="Enter company name"
+                  placeholder={translations[language].placeholderName}
                 />
               </div>
             </div>
@@ -166,7 +169,7 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
                 htmlFor="companyUrl"
                 className="block text-base font-medium text-gray-700 mb-2.5 transition-all duration-200 group-hover:text-gray-900 font-['DM_Sans']"
               >
-                Company URL
+                {translations[language].companyUrl}
               </label>
               <div className="relative">
                 <div className="absolute inset-0 bg-gradient-to-r from-gray-50/0 via-gray-100/50 to-gray-50/0 opacity-0 group-hover:opacity-100 transition-opacity duration-500 rounded-lg"></div>
@@ -182,7 +185,7 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
                     }))
                   }
                   className={`${glassStyle.input} transition-all duration-300 focus:border-[#468BFF]/50 focus:ring-1 focus:ring-[#468BFF]/50 group-hover:border-[#468BFF]/30 bg-white/80 backdrop-blur-sm text-lg py-4 pl-12 font-['DM_Sans']`}
-                  placeholder="example.com"
+                  placeholder={translations[language].placeholderUrl}
                 />
               </div>
             </div>
@@ -193,7 +196,7 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
                 htmlFor="companyHq"
                 className="block text-base font-medium text-gray-700 mb-2.5 transition-all duration-200 group-hover:text-gray-900 font-['DM_Sans']"
               >
-                Company HQ
+                {translations[language].companyHq}
               </label>
               <LocationInput
                 value={formData.companyHq}
@@ -213,7 +216,7 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
                 htmlFor="companyIndustry"
                 className="block text-base font-medium text-gray-700 mb-2.5 transition-all duration-200 group-hover:text-gray-900 font-['DM_Sans']"
               >
-                Company Industry
+                {translations[language].companyIndustry}
               </label>
               <div className="relative">
                 <div className="absolute inset-0 bg-gradient-to-r from-gray-50/0 via-gray-100/50 to-gray-50/0 opacity-0 group-hover:opacity-100 transition-opacity duration-500 rounded-lg"></div>
@@ -229,7 +232,7 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
                     }))
                   }
                   className={`${glassStyle.input} transition-all duration-300 focus:border-[#468BFF]/50 focus:ring-1 focus:ring-[#468BFF]/50 group-hover:border-[#468BFF]/30 bg-white/80 backdrop-blur-sm text-lg py-4 pl-12 font-['DM_Sans']`}
-                  placeholder="e.g. Technology, Healthcare"
+                  placeholder={translations[language].placeholderIndustry}
                 />
               </div>
             </div>
@@ -245,12 +248,12 @@ const ResearchForm: React.FC<ResearchFormProps> = ({
               {isResearching ? (
                 <>
                   <Loader2 className="animate-spin -ml-1 mr-2 h-5 w-5 loader-icon" style={{ stroke: loaderColor }} />
-                  <span className="text-base font-medium text-gray-900/90">Researching...</span>
+                  <span className="text-base font-medium text-gray-900/90">{translations[language].researching}</span>
                 </>
               ) : (
                 <>
                   <Search className="-ml-1 mr-2 h-5 w-5 text-gray-900/90" />
-                  <span className="text-base font-medium text-gray-900/90">Start Research</span>
+                  <span className="text-base font-medium text-gray-900/90">{translations[language].startResearch}</span>
                 </>
               )}
             </div>

--- a/ui/src/components/ResearchQueries.tsx
+++ b/ui/src/components/ResearchQueries.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { ResearchQueriesProps } from '../types';
+import { translations } from '../utils/translations';
 
-const ResearchQueries: React.FC<ResearchQueriesProps> = ({
+const ResearchQueries: React.FC<ResearchQueriesProps & { language: 'en' | 'ja' }> = ({
   queries,
   streamingQueries,
   isExpanded,
   onToggleExpand,
   isResetting,
-  glassStyle
+  glassStyle,
+  language
 }) => {
   const glassCardStyle = `${glassStyle} rounded-2xl p-6`;
   const fadeInAnimation = "transition-all duration-300 ease-in-out";
@@ -22,7 +24,7 @@ const ResearchQueries: React.FC<ResearchQueriesProps> = ({
         onClick={onToggleExpand}
       >
         <h2 className="text-xl font-semibold text-gray-900">
-          Generated Research Queries
+          {translations[language].generatedQueries}
         </h2>
         <button className="text-gray-600 hover:text-gray-900 transition-colors">
           {isExpanded ? (
@@ -68,7 +70,7 @@ const ResearchQueries: React.FC<ResearchQueriesProps> = ({
       
       {!isExpanded && (
         <div className="mt-2 text-sm text-gray-600">
-          {queries.length} queries generated across {['company', 'industry', 'financial', 'news'].length} categories
+          {queries.length} {language === 'ja' ? '件のクエリが生成されました' : 'queries generated'}
         </div>
       )}
     </div>
@@ -76,3 +78,4 @@ const ResearchQueries: React.FC<ResearchQueriesProps> = ({
 };
 
 export default ResearchQueries; 
+

--- a/ui/src/utils/translations.ts
+++ b/ui/src/utils/translations.ts
@@ -1,0 +1,30 @@
+export const translations = {
+  en: {
+    title: "Company Research Agent",
+    tagline: "Conduct in-depth company diligence powered by Tavily",
+    companyName: "Company Name",
+    companyUrl: "Company URL",
+    companyHq: "Company HQ",
+    companyIndustry: "Company Industry",
+    placeholderName: "Enter company name",
+    placeholderUrl: "example.com",
+    placeholderIndustry: "e.g. Technology, Healthcare",
+    startResearch: "Start Research",
+    researching: "Researching...",
+    generatedQueries: "Generated Research Queries",
+  },
+  ja: {
+    title: "企業調査エージェント",
+    tagline: "Tavily が支える詳細な企業調査",
+    companyName: "企業名",
+    companyUrl: "企業URL",
+    companyHq: "本社所在地",
+    companyIndustry: "業界",
+    placeholderName: "企業名を入力",
+    placeholderUrl: "example.com",
+    placeholderIndustry: "例: テクノロジー、ヘルスケア",
+    startResearch: "調査開始",
+    researching: "調査中...",
+    generatedQueries: "生成された調査クエリ",
+  }
+} as const;


### PR DESCRIPTION
## Summary
- add `language` field in backend state and Graph initialization
- pass language through API to backend and include in prompts
- update prompts to respond in Japanese when selected
- add language toggle in UI header
- localize form labels and messages with translations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python -m py_compile $(git ls-files '*.py')`